### PR TITLE
Use already included find_boost if not building standalone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 set (NANO_POW_SERVER_TEST OFF CACHE BOOL "")
 set (NANO_POW_STANDALONE OFF CACHE BOOL "")
+set (NANO_SHARED_BOOST OFF CACHE BOOL "")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -46,11 +47,14 @@ find_package(Threads REQUIRED)
 #	include_directories (${OpenCL_INCLUDE_DIRS})
 #	link_directories (${OpenCL_LIBRARY})
 #endif ()
+if (NANO_POW_STANDALONE)
+	if (NOT NANO_SHARED_BOOST)
+		set(Boost_USE_STATIC_LIBS        ON)
+		set(Boost_USE_MULTITHREADED      ON)
 
-set(Boost_USE_STATIC_LIBS        ON)
-set(Boost_USE_MULTITHREADED      ON)
-
-find_package (Boost 1.69.0 REQUIRED COMPONENTS filesystem thread program_options system)
+		find_package (Boost 1.69.0 REQUIRED COMPONENTS filesystem thread program_options system)
+	endif()
+endif ()
 include_directories (src)
 
 add_definitions(-DFMT_HEADER_ONLY)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ CMake is used for building. C++14 and Boost 1.69 or later is required. Other dep
 
 ```
 git clone --recursive https://github.com/nanocurrency/nano-pow-server.git
-cmake .
+cd nano-pow-server; mkdir build; cd build
+cmake -DNANO_POW_STANDALONE=ON ..
 make
 ```
 


### PR DESCRIPTION
adds support for using as a submodule of nano-node and still honoring shared boost if selected, leaves standalone as static boost