### PR TITLE
Update CPU threads dedicated for build

### DIFF
--- a/ci/actions/build.sh
+++ b/ci/actions/build.sh
@@ -26,24 +26,24 @@ if [[ ${RUN} == "artifact" ]]; then
         cmake --build . \
             --target package \
             --config Release \
-            -- -j2
+            -- -j $(nproc)
     else
         sudo cmake --build . \
             --target package \
             --config Release \
-            -- -j2
+            -- -j $(nproc)
     fi
 else
     if [[ "$OS" == 'Linux' ]]; then
         cmake --build . \
             --target tests \
             --config Debug \
-            -- -j2
+            -- -j $(nproc)
     else
         sudo cmake --build . \
             --target tests \
             --config Debug \
-            -- -j2
+            -- -j $(nproc)
     fi
     ./tests
 fi


### PR DESCRIPTION
Changed the static threads count assigned in "ci/actions/build.sh" to dynamically pick up all the threads available for faster builds.